### PR TITLE
Migrate CMakeLists.txt from Qt5 to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.21)
 project(hands-timesync VERSION 0.1)
 
-find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Core REQUIRED)
+find_package(Qt6 COMPONENTS Core REQUIRED)
 
 add_executable(hands-timesync handsTimesync.cpp)
-target_link_libraries(hands-timesync PRIVATE Qt5::Core)
+target_link_libraries(hands-timesync PRIVATE Qt::Core)
 install(TARGETS hands-timesync DESTINATION bin)
 install(FILES hands-timesync.service hands-timesync.timer
 		DESTINATION /usr/lib/systemd/system)


### PR DESCRIPTION
The recipe already uses inherit qt6-cmake but CMakeLists.txt still referenced Qt5, causing the build to fail with a missing Qt5Config.cmake error on Qt6 images.

Replace find_package(Qt5) with find_package(Qt6) and update the target_link_libraries call from Qt5::Core to the version-agnostic Qt::Core target.